### PR TITLE
Added functionality to skip sending messages based on probability

### DIFF
--- a/src/iotswarm/scripts/cli.py
+++ b/src/iotswarm/scripts/cli.py
@@ -169,6 +169,7 @@ def mqtt(
     mqtt_suffix,
     dry,
     device_type,
+    no_send_probability,
 ):
     """Sends The cosmos data via MQTT protocol using IoT Core.
     Data is from the cosmos database TABLE and sent using CLIENT_ID.
@@ -217,6 +218,7 @@ def mqtt(
                 mqtt_prefix=mqtt_prefix,
                 mqtt_suffix=mqtt_suffix,
                 inherit_logger=ctx.obj["logger"],
+                no_send_probability=no_send_probability
             )
             for site in sites
         ]
@@ -284,6 +286,7 @@ def mqtt(
     dry,
     device_type,
     resume_session,
+    no_send_probability,
 ):
     """Sends The cosmos data via MQTT protocol using IoT Core.
     Data is collected from the db using QUERY and sent using CLIENT_ID.
@@ -314,6 +317,8 @@ def mqtt(
                 swarm.devices[i].mqtt_prefix = mqtt_prefix
             if mqtt_suffix is not None:
                 swarm.devices[i].mqtt_suffix = mqtt_suffix
+            if no_send_probability is not None:
+                swarm.devices[i].no_send_probability = no_send_probability
 
         click.echo("Loaded swarm from pickle")
 
@@ -354,6 +359,7 @@ def mqtt(
                 mqtt_prefix=mqtt_prefix,
                 mqtt_suffix=mqtt_suffix,
                 inherit_logger=ctx.obj["logger"],
+                no_send_probability=no_send_probability,
             )
             for site in sites
         ]
@@ -440,6 +446,7 @@ def mqtt(
     dry,
     device_type,
     resume_session,
+    no_send_probability,
 ):
     """Sends The cosmos data via MQTT protocol using IoT Core.
     Data is collected from the db using QUERY and sent using CLIENT_ID.
@@ -472,6 +479,8 @@ def mqtt(
                 swarm.devices[i].mqtt_prefix = mqtt_prefix
             if mqtt_suffix is not None:
                 swarm.devices[i].mqtt_suffix = mqtt_suffix
+            if no_send_probability is not None:
+                swarm.devices[i].no_send_probability = no_send_probability
 
         click.echo(swarm.devices[0].cycle)
         click.echo("Loaded swarm from pickle")
@@ -514,6 +523,7 @@ def mqtt(
                 mqtt_suffix=mqtt_suffix,
                 table=table,
                 inherit_logger=ctx.obj["logger"],
+                no_send_probability=no_send_probability
             )
             for site in sites
         ]

--- a/src/iotswarm/scripts/common.py
+++ b/src/iotswarm/scripts/common.py
@@ -39,6 +39,12 @@ def device_options(function):
         "--device-type", type=click.Choice(["basic", "cr1000x"]), default="basic"
     )(function)
 
+    click.option(
+        "--no-send-probability",
+        type=click.IntRange(0, 100),
+        help="Probability of not sending a message, can be 0 - 100 where 0 is no skip and 100 is always skip",
+    )(function)
+
     return function
 
 


### PR DESCRIPTION
These changes allow devices to be initialized with a probability value from 0 - 100 that randomly skips sending the next message based on that probability.

## Cases
* **0 probability:** message is always sent (the default is 0)
* **1-99 probability:** message has 1% - 99% of being skipped
* **100 probability:** message is never sent

## Note
The CLI can't really be tested outside of production but it should work as intended as the unit tests are passing