### PR TITLE
Updated livecosmos to match campbell logger topic format

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -18,6 +18,7 @@ aws: {
     endpoint_url: "<s3_endpoint_url>" #if running locally
     bucket: "<s3_bucket>"
     bucket_prefix: "<s3_bucket_prefix>" # Write to a specific S3 folder
+    bucker_suffix: "<s3_bucket_suffix>" # Added to the end of the MQTT base topic
 }
 ```
 The module is invoked via the command line:

--- a/src/iotswarm/__assets__/live_cosmos_tests.cfg
+++ b/src/iotswarm/__assets__/live_cosmos_tests.cfg
@@ -13,5 +13,6 @@ iot_core: {
 aws: {
     endpoint_url: "http://localhost:4566"
     bucket: "testbucket"
-    bucket_prefix: "fdri/cosmos_swarm"
+    bucket_prefix: "fdri/cosmos_swarm/data"
+    topic_suffix: "json"
 }

--- a/src/iotswarm/livecosmos/liveupload.py
+++ b/src/iotswarm/livecosmos/liveupload.py
@@ -44,6 +44,9 @@ class LiveUploader:
     bucket_prefix: Optional[str]
     """Prefix of the path used in the S3 bucket"""
 
+    topic_suffix: Optional[str]
+    """Suffix of the base path used in the S3 bucket"""
+
     _s3_manager: S3Writer
     """Object for handling writes to S3"""
 
@@ -53,7 +56,8 @@ class LiveUploader:
         table: CosmosTable,
         sites: List[str],
         bucket: str,
-        bucket_prefix: Optional[str] = None,
+        bucket_prefix: str = "",
+        topic_suffix: str = "",
         app_prefix: str = "livecosmos",
         fallback_hours: int = 3,
     ) -> None:
@@ -65,6 +69,7 @@ class LiveUploader:
             sites: A list of sites to search new records
             bucket: Name of the S3 bucket that is written to
             bucket_prefix: Prefix added to the bucket path
+            topic_suffix: Suffix added to the bucket path
             app_prefix: Prefix added to the state files
             fallback_hours: The number of hours to fallback to if no state is found
         """
@@ -74,6 +79,7 @@ class LiveUploader:
         self.sites = sites
         self.bucket = bucket
         self.bucket_prefix = bucket_prefix
+        self.topic_suffix = topic_suffix
         self._app_prefix = app_prefix
         self.state = StateTracker(str(table), app_name=app_prefix)
         self._fallback_time = datetime.now() - timedelta(hours=fallback_hours)
@@ -158,10 +164,11 @@ class LiveUploader:
         """
 
         table_name = f"LIVE_{self.table.replace('LEVEL1_', '')}"
-        key = f"{site_id}/{table_name}/{object_name}"
 
-        if self.bucket_prefix:
-            key = f"{self.bucket_prefix}/{key}"
+        key = (
+            f"{self.bucket_prefix}{'/' if self.bucket_prefix else ''}"
+            f"{site_id}/{table_name}{'/' if self.topic_suffix else ''}{self.topic_suffix}/{object_name}"
+        )
 
         return key
 

--- a/src/iotswarm/livecosmos/scripts/cli.py
+++ b/src/iotswarm/livecosmos/scripts/cli.py
@@ -40,7 +40,15 @@ async def send_latest(
         batch_size: Maximum number of data rows in each message
     """
 
+    bucket_prefix = None
+    topic_suffix = None
+
     app_config = Config(str(config_file))
+
+    if "bucket_prefix" in app_config["aws"]:
+        bucket_prefix = app_config["aws"]["bucket_prefix"]
+    if "topic_suffix" in app_config["aws"]:
+        topic_suffix = app_config["aws"]["topic_suffix"]
 
     oracle = await Oracle.create(**app_config["oracle"])
 
@@ -52,7 +60,8 @@ async def send_latest(
         CosmosTable[table],
         sites,
         app_config["aws"]["bucket"],
-        bucket_prefix=app_config["aws"]["bucket_prefix"],
+        bucket_prefix=bucket_prefix,
+        topic_suffix=topic_suffix,
         fallback_hours=fallback_hours,
     )
 

--- a/tests/livecosmos/end_to_end/test_livecosmos.py
+++ b/tests/livecosmos/end_to_end/test_livecosmos.py
@@ -205,7 +205,7 @@ class TestCLI(TestCase):
         ),
     )
     def test_all(self):
-        _BUCKET_PREFIX = "fdri/cosmos_swarm"
+        _BUCKET_PREFIX = "fdri/cosmos_swarm/data"
 
         sites = ["test_site1", "test_site2"]
         runner = CliRunner()
@@ -227,7 +227,8 @@ class TestCLI(TestCase):
                 for item in items:
                     # Test that the object key is correct
                     object_key = item["Key"]
-                    expected_key_start = f"{_BUCKET_PREFIX}/{site}/{table}/"
+
+                    expected_key_start = f"{_BUCKET_PREFIX}/{site}/{table}/json"
                     self.assertTrue(object_key.startswith(expected_key_start))
 
                     # Test site name is in the payload

--- a/tests/livecosmos/test_livecosmos_liveupload.py
+++ b/tests/livecosmos/test_livecosmos_liveupload.py
@@ -56,7 +56,7 @@ class TestCosmosUploader(TestCase):
             ],
             [
                 CosmosTable.LEVEL_1_SOILMET_30MIN,
-                None,
+                "",
                 "ALIC1/LIVE_SOILMET_30MIN/payload_hash.json",
             ],
         ]


### PR DESCRIPTION
Adds config entry for controlling the topic that files are uploaded to to match the campbell:

.../data/<topic>/cj/<filename>

But changes cj to json because we use json not csijson